### PR TITLE
[DEV] Reworked notifications for starred sessions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,8 @@
 
     <uses-permission android:name="android.permission.VIBRATE"/>
 
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
     <application
         android:name=".AndroidMakersApplication"
         android:allowBackup="true"

--- a/app/src/main/java/fr/paug/androidmakers/manager/AgendaRepository.java
+++ b/app/src/main/java/fr/paug/androidmakers/manager/AgendaRepository.java
@@ -48,7 +48,7 @@ public class AgendaRepository {
                 mFirebaseDataConverted.loadAllFromFirebase(dataSnapshot.getValue());
                 List<OnLoadListener> listenersCpy = new ArrayList<>(mOnLoadListeners);
                 for (OnLoadListener listener : listenersCpy) {
-                    listener.onAgendaLoaded(true);
+                    listener.onAgendaLoaded();
                 }
                 mLoaded = true;
                 Log.e(TAG, "AgendaRepo loaded");
@@ -71,7 +71,7 @@ public class AgendaRepository {
 
     public void load(OnLoadListener listener) {
         if (mLoaded) {
-            listener.onAgendaLoaded(false);
+            listener.onAgendaLoaded();
             return;
         }
         mOnLoadListeners.add(listener);
@@ -131,7 +131,7 @@ public class AgendaRepository {
     }
 
     public interface OnLoadListener {
-        void onAgendaLoaded(boolean newData);
+        void onAgendaLoaded();
     }
 
     private static class SingletonHolder {

--- a/app/src/main/java/fr/paug/androidmakers/service/SessionAlarmService.java
+++ b/app/src/main/java/fr/paug/androidmakers/service/SessionAlarmService.java
@@ -7,6 +7,7 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.NonNull;
 import android.support.v4.app.NotificationCompat;
 import android.text.format.DateUtils;
 import android.util.Log;
@@ -14,9 +15,11 @@ import android.util.Log;
 import java.util.Date;
 import java.util.Formatter;
 import java.util.List;
+import java.util.Locale;
 
 import fr.paug.androidmakers.R;
 import fr.paug.androidmakers.manager.AgendaRepository;
+import fr.paug.androidmakers.model.Room;
 import fr.paug.androidmakers.model.ScheduleSlot;
 import fr.paug.androidmakers.model.Session;
 import fr.paug.androidmakers.ui.activity.MainActivity;
@@ -27,30 +30,23 @@ public class SessionAlarmService extends IntentService {
     private static final String TAG = "sessionAlarm";
 
     public static final String ACTION_NOTIFY_SESSION = "NOTIFY_SESSION";
-    public static final String ACTION_REMOVE_NOTIFY_SESSION = "REMOVE_NOTIFY_SESSION";
 
     public static final String ACTION_SCHEDULE_STARRED_BLOCK = "SCHEDULE_STARRED_BLOCK";
+    public static final String ACTION_UNSCHEDULE_UNSTARRED_BLOCK = "ACTION_UNSCHEDULE_UNSTARRED_BLOCK";
     public static final String ACTION_SCHEDULE_ALL_STARRED_BLOCKS = "SCHEDULE_ALL_STARRED_BLOCKS";
 
     public static final String EXTRA_SESSION_ID = "SESSION_ID";
     public static final String EXTRA_SESSION_START = "SESSION_START";
     public static final String EXTRA_SESSION_END = "SESSION_END";
-
-    public static final String EXTRA_SESSION_ALARM_OFFSET = "SESSION_ALARM_OFFSET";
-
-    public static final String EXTRA_SESSION_ADD = "SESSION_ADD";
-    public static final String EXTRA_SESSION_REMOVE = "SESSION_REMOVE";
-
-    public static final int NOTIFICATION_ID = 100;
+    public static final String EXTRA_NOTIF_TITLE = "NOTIF_TITLE";
+    public static final String EXTRA_NOTIF_CONTENT = "NOTIF_CONTENT";
 
     private static final int NOTIFICATION_LED_ON_MS = 100;
     private static final int NOTIFICATION_LED_OFF_MS = 1000;
     private static final int NOTIFICATION_ARGB_COLOR = 0xff1EB6E1;
 
-    private static final long MILLI_TEN_MINUTES = 600000;
     private static final long MILLI_FIVE_MINUTES = 300000;
 
-    private static final long UNDEFINED_ALARM_OFFSET = -1;
     private static final long UNDEFINED_VALUE = -1;
 
     public SessionAlarmService() {
@@ -73,46 +69,99 @@ public class SessionAlarmService extends IntentService {
         final int sessionId = intent.getIntExtra(SessionAlarmService.EXTRA_SESSION_ID, 0);
 
         if (ACTION_NOTIFY_SESSION.equals(action)) {
+            final String notifTitle = intent.getStringExtra(SessionAlarmService.EXTRA_NOTIF_TITLE);
+            final String notifContent = intent.getStringExtra(SessionAlarmService.EXTRA_NOTIF_CONTENT);
+            if (notifTitle == null || notifContent == null) {
+                Log.w(TAG, "Title or content of the notification is null.");
+                return;
+            }
             LOGD(TAG, "Notifying about sessions starting at " +
                     sessionStart + " = " + (new Date(sessionStart)).toString());
-            notifySession(sessionStart);
+            notifySession(sessionId, notifTitle, notifContent);
         } else if (ACTION_SCHEDULE_STARRED_BLOCK.equals(action)) {
             LOGD(TAG, "Scheduling session alarm.");
             LOGD(TAG, "-> Session start: " + sessionStart + " = " + (new Date(sessionStart))
                     .toString());
             LOGD(TAG, "-> Session end: " + sessionEnd + " = " + (new Date(sessionEnd)).toString());
-            scheduleAlarm(sessionStart, sessionEnd, sessionId, MILLI_FIVE_MINUTES);
+            scheduleAlarm(sessionStart, sessionEnd, sessionId, true);
+        } else if (ACTION_UNSCHEDULE_UNSTARRED_BLOCK.equals(action)) {
+            LOGD(TAG, "Unscheduling session alarm for id " + sessionId);
+            unscheduleAlarm(sessionId);
         }
     }
 
     void scheduleAllStarredSessions() {
-        List<ScheduleSlot> scheduleSlots = AgendaRepository.getInstance().getScheduleSlots();
+        // need to be sure that the AngendaRepository is loaded in order to schedule all starred sessions
+        final Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                final List<ScheduleSlot> scheduleSlots = AgendaRepository.getInstance()
+                        .getScheduleSlots();
 
-        for (String id : SessionSelector.getInstance().getSessionsSelected()) {
-            for (ScheduleSlot scheduleSlot : scheduleSlots) {
-                if (String.valueOf(scheduleSlot.sessionId) == id) {
-                    Log.i("SessionAlarmService", scheduleSlot.toString());
-                    scheduleAlarm(scheduleSlot.startDate, scheduleSlot.endDate, scheduleSlot.sessionId, MILLI_FIVE_MINUTES);
+                // first unschedule all sessions
+                // this is done in case the session slot has changed
+                for (ScheduleSlot scheduleSlot : scheduleSlots) {
+                    unscheduleAlarm(scheduleSlot.sessionId);
+                }
+
+                for (String id : SessionSelector.getInstance().getSessionsSelected()) {
+                    ScheduleSlot scheduleSlot = AgendaRepository.getInstance().getScheduleSlot(id);
+                    if (scheduleSlot != null) {
+                        Log.i("SessionAlarmService", scheduleSlot.toString());
+                        scheduleAlarm(scheduleSlot.startDate, scheduleSlot.endDate,
+                                scheduleSlot.sessionId, false);
+                    }
                 }
             }
-        }
+        };
+        AgendaRepository.getInstance().load(new AgendaLoadListener(runnable));
     }
 
-    private void scheduleAlarm(final long sessionStart, final long sessionEnd, int sessionId, final long alarmOffset) {
-        NotificationManager nm =
-                (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-        nm.cancel(NOTIFICATION_ID);
+    /**
+     * Schedule an alarm for a given session that begins at a given time
+     * @param sessionStart start time of the slot. The alarm will be fired before this time
+     * @param sessionEnd end time of the slot
+     * @param sessionId id of the session
+     * @param allowLastMinute allow or not the alarm to be set if the delay between the alarm and
+     *                        the session start is over.
+     */
+    private void scheduleAlarm(final long sessionStart, final long sessionEnd, int sessionId,
+                               boolean allowLastMinute) {
         final long currentTime = System.currentTimeMillis();
 
         Log.i("Time", "current: " + currentTime + ", session start: " + sessionStart);
 
-        // If the session is already started, do not schedule system notification.
-        if (currentTime > sessionStart) {
-            LOGD(TAG, "Not scheduling alarm because target time is in the past: " + sessionStart);
+        final long alarmTime = sessionStart - MILLI_FIVE_MINUTES;
+
+        if (allowLastMinute) {
+            // If the session is already started, do not schedule system notification.
+            if (currentTime > sessionStart) {
+                LOGD(TAG, "Not scheduling alarm because target time is in the past: " + sessionStart);
+                return;
+            }
+        } else {
+            if (currentTime > alarmTime) {
+                LOGD(TAG, "Not scheduling alarm because alarm time is in the past: " + alarmTime);
+                return;
+            }
+        }
+
+        final Session sessionToNotify = AgendaRepository.getInstance().getSession(sessionId);
+        final ScheduleSlot slotToNotify = AgendaRepository.getInstance().getScheduleSlot(sessionId);
+        if (sessionToNotify == null || slotToNotify == null) {
+            Log.w(TAG, "Cannot find session " + sessionId + " either in sessions or in slots");
             return;
         }
 
-        long alarmTime = sessionStart - MILLI_FIVE_MINUTES;
+        final String sessionDate = DateUtils.formatDateRange(this,
+                new Formatter(Locale.getDefault()),
+                slotToNotify.startDate,
+                slotToNotify.endDate,
+                DateUtils.FORMAT_SHOW_WEEKDAY | DateUtils.FORMAT_ABBREV_WEEKDAY | DateUtils.FORMAT_SHOW_TIME,
+                null).toString();
+
+        final Room room = AgendaRepository.getInstance().getRoom(slotToNotify.room);
+        final String roomName = ((room != null) ? room.name : "") + " - ";
 
         LOGD(TAG, "Scheduling alarm for " + alarmTime + " = " + (new Date(alarmTime)).toString());
 
@@ -125,10 +174,12 @@ public class SessionAlarmService extends IntentService {
         LOGD(TAG, "-> Intent extra: session start " + sessionStart);
         notifIntent.putExtra(EXTRA_SESSION_END, sessionEnd);
         LOGD(TAG, "-> Intent extra: session end " + sessionEnd);
-        notifIntent.putExtra(EXTRA_SESSION_ALARM_OFFSET, alarmOffset);
-        LOGD(TAG, "-> Intent extra: session alarm offset " + alarmOffset);
+        notifIntent.putExtra(EXTRA_SESSION_ID, sessionId);
+        notifIntent.putExtra(EXTRA_NOTIF_TITLE, sessionToNotify.title);
+        notifIntent.putExtra(EXTRA_NOTIF_CONTENT, roomName + sessionDate);
 
-        PendingIntent pi = PendingIntent.getService(this, sessionId, notifIntent, PendingIntent.FLAG_ONE_SHOT);
+        PendingIntent pi = PendingIntent.getService(this, sessionId, notifIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT);
 
         final AlarmManager am = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
         // Schedule an alarm to be fired to notify user of added sessions are about to begin.
@@ -136,38 +187,26 @@ public class SessionAlarmService extends IntentService {
         am.set(AlarmManager.RTC_WAKEUP, alarmTime, pi);
     }
 
-    // Starred sessions are about to begin.  Constructs and triggers system notification.
-    private void notifySession(final long sessionStart) {
-        long currentTime = System.currentTimeMillis();
-        final long intervalEnd = sessionStart + MILLI_TEN_MINUTES;
-        LOGD(TAG, "Considering notifying for time interval.");
-        LOGD(TAG, "    Interval start: " + sessionStart + "=" + (new Date(sessionStart)).toString());
-        LOGD(TAG, "    Interval end: " + intervalEnd + "=" + (new Date(intervalEnd)).toString());
-        LOGD(TAG, "    Current time is: " + currentTime + "=" + (new Date(currentTime)).toString());
+    /**
+     * Remove the scheduled alarm for a given session
+     * @param sessionId the id of the session
+     */
+    private void unscheduleAlarm(int sessionId) {
+        final AlarmManager am = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
+        final Intent notifIntent = new Intent(
+                ACTION_NOTIFY_SESSION,
+                null,
+                this,
+                SessionAlarmService.class);
+        PendingIntent pi = PendingIntent.getService(this, sessionId, notifIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT);
 
-        // Find sessions details
-        LOGD(TAG, "Looking for sessions in interval " + sessionStart + " - " + intervalEnd);
+        am.cancel(pi);
+    }
 
-        List<ScheduleSlot> scheduleSlots = AgendaRepository.getInstance().getScheduleSlots();
-
-        ScheduleSlot slotToNotify = null;
-        for (ScheduleSlot scheduleSlot : scheduleSlots) {
-            if (scheduleSlot.startDate == sessionStart) {
-                Log.d(TAG, "schedule to start: " + scheduleSlot.toString());
-                if (SessionSelector.getInstance().getSessionsSelected().contains(String.valueOf(scheduleSlot.sessionId))) {
-                    Log.d(TAG, "starred schedule slot:" + scheduleSlot.sessionId);
-                    slotToNotify = scheduleSlot;
-                }
-            }
-        }
-
-        Session sessionToNotify = AgendaRepository.getInstance().getSession(slotToNotify.sessionId);
-        final String sessionDate = DateUtils.formatDateRange(this, new Formatter(getResources().getConfiguration().locale),
-                slotToNotify.startDate,
-                slotToNotify.endDate,
-                DateUtils.FORMAT_SHOW_WEEKDAY | DateUtils.FORMAT_ABBREV_WEEKDAY | DateUtils.FORMAT_SHOW_TIME,
-                null).toString();
-
+    // Starred sessions are about to begin. Constructs and triggers system notification.
+    private void notifySession(int sessionId, @NonNull String notifTitle,
+                               @NonNull String notifContent) {
         // Generates the pending intent which gets fired when the user taps on the notification.
         Intent baseIntent = new Intent(this, MainActivity.class);
         baseIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
@@ -182,8 +221,8 @@ public class SessionAlarmService extends IntentService {
                 );
 
         NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this)
-                .setContentTitle(sessionToNotify.title)
-                .setContentText(sessionDate)
+                .setContentTitle(notifTitle)
+                .setContentText(notifContent)
                 .setColor(getResources().getColor(R.color.colorPrimary))
                 .setDefaults(Notification.DEFAULT_SOUND | Notification.DEFAULT_VIBRATE)
                 .setLights(
@@ -198,11 +237,25 @@ public class SessionAlarmService extends IntentService {
         NotificationManager notificationManager = (NotificationManager) getSystemService(
                 Context.NOTIFICATION_SERVICE);
         LOGD(TAG, "Now showing notification.");
-        notificationManager.notify(NOTIFICATION_ID, notificationBuilder.build());
+        notificationManager.notify(sessionId, notificationBuilder.build());
     }
 
     public static void LOGD(final String tag, String message) {
         Log.d(tag, message);
     }
 
+    private static class AgendaLoadListener implements AgendaRepository.OnLoadListener {
+        @NonNull
+        private final Runnable runnable;
+
+        private AgendaLoadListener(@NonNull Runnable runnable) {
+            this.runnable = runnable;
+        }
+
+        @Override
+        public void onAgendaLoaded(boolean newData) {
+            runnable.run();
+            AgendaRepository.getInstance().removeListener(this);
+        }
+    }
 }

--- a/app/src/main/java/fr/paug/androidmakers/service/SessionAlarmService.java
+++ b/app/src/main/java/fr/paug/androidmakers/service/SessionAlarmService.java
@@ -253,7 +253,7 @@ public class SessionAlarmService extends IntentService {
         }
 
         @Override
-        public void onAgendaLoaded(boolean newData) {
+        public void onAgendaLoaded() {
             runnable.run();
             AgendaRepository.getInstance().removeListener(this);
         }

--- a/app/src/main/java/fr/paug/androidmakers/ui/activity/DetailActivity.java
+++ b/app/src/main/java/fr/paug/androidmakers/ui/activity/DetailActivity.java
@@ -174,17 +174,30 @@ public class DetailActivity extends AppCompatActivity {
             scheduleStarredSession();
         } else {
             Toast.makeText(this, R.string.session_deselected, Toast.LENGTH_SHORT).show();
-            // TODO: 03/04/2017 remove notification
+            unscheduleSession();
         }
     }
 
     private void scheduleStarredSession() {
-        Log.d("Detail", "Scheduling notification about session start. start time : " + sessionStartDateInMillis + ", end time : " + sessionEndDateInMillis);
-        Intent scheduleIntent = new Intent(
+        Log.d("Detail", "Scheduling notification about session start. " +
+                "start time : " + sessionStartDateInMillis + ", " +
+                "end time : " + sessionEndDateInMillis);
+        final Intent scheduleIntent = new Intent(
                 SessionAlarmService.ACTION_SCHEDULE_STARRED_BLOCK,
                 null, this, SessionAlarmService.class);
         scheduleIntent.putExtra(SessionAlarmService.EXTRA_SESSION_START, sessionStartDateInMillis);
         scheduleIntent.putExtra(SessionAlarmService.EXTRA_SESSION_END, sessionEndDateInMillis);
+        scheduleIntent.putExtra(SessionAlarmService.EXTRA_SESSION_ID, sessionId);
+        startService(scheduleIntent);
+    }
+
+    private void unscheduleSession() {
+        Log.d("Detail", "Unscheduling notification about session start. " +
+                "start time : " + sessionStartDateInMillis + ", " +
+                "end time : " + sessionEndDateInMillis);
+        final Intent scheduleIntent = new Intent(
+                SessionAlarmService.ACTION_UNSCHEDULE_UNSTARRED_BLOCK,
+                null, this, SessionAlarmService.class);
         scheduleIntent.putExtra(SessionAlarmService.EXTRA_SESSION_ID, sessionId);
         startService(scheduleIntent);
     }

--- a/app/src/main/java/fr/paug/androidmakers/ui/fragment/AgendaFragment.java
+++ b/app/src/main/java/fr/paug/androidmakers/ui/fragment/AgendaFragment.java
@@ -286,7 +286,7 @@ public class AgendaFragment extends Fragment implements AgendaView.AgendaClickLi
         }
 
         @Override
-        public void onAgendaLoaded(boolean newData) {
+        public void onAgendaLoaded() {
             AgendaFragment agendaFragment = reference.get();
             if (agendaFragment == null) {
                 return;
@@ -294,7 +294,7 @@ public class AgendaFragment extends Fragment implements AgendaView.AgendaClickLi
             agendaFragment.onAgendaLoaded();
 
             final AgendaFragment fragment = reference.get();
-            if (newData && fragment != null) {
+            if (fragment != null) {
                 // reschedule all starred blocks in case one session start or stop time has changed
                 final Context ctx = fragment.getContext();
                 Intent scheduleIntent = new Intent(

--- a/app/src/main/java/fr/paug/androidmakers/ui/fragment/AgendaFragment.java
+++ b/app/src/main/java/fr/paug/androidmakers/ui/fragment/AgendaFragment.java
@@ -1,5 +1,7 @@
 package fr.paug.androidmakers.ui.fragment;
 
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
@@ -29,6 +31,7 @@ import fr.paug.androidmakers.manager.AgendaRepository;
 import fr.paug.androidmakers.model.Room;
 import fr.paug.androidmakers.model.ScheduleSlot;
 import fr.paug.androidmakers.model.Session;
+import fr.paug.androidmakers.service.SessionAlarmService;
 import fr.paug.androidmakers.ui.activity.DetailActivity;
 import fr.paug.androidmakers.ui.adapter.AgendaPagerAdapter;
 import fr.paug.androidmakers.ui.util.AgendaFilterMenu;
@@ -283,12 +286,22 @@ public class AgendaFragment extends Fragment implements AgendaView.AgendaClickLi
         }
 
         @Override
-        public void onAgendaLoaded() {
+        public void onAgendaLoaded(boolean newData) {
             AgendaFragment agendaFragment = reference.get();
             if (agendaFragment == null) {
                 return;
             }
             agendaFragment.onAgendaLoaded();
+
+            final AgendaFragment fragment = reference.get();
+            if (newData && fragment != null) {
+                // reschedule all starred blocks in case one session start or stop time has changed
+                final Context ctx = fragment.getContext();
+                Intent scheduleIntent = new Intent(
+                        SessionAlarmService.ACTION_SCHEDULE_ALL_STARRED_BLOCKS,
+                        null, ctx, SessionAlarmService.class);
+                ctx.startService(scheduleIntent);
+            }
         }
     }
 }


### PR DESCRIPTION
Show the room on the notifications
Allow multiple notifications if there are several starred sessions that begins at the same time.
Remove the alarm when a session is unstarred.
When the data source is updated, recreate all alarms in case the schedule has changed.
Fixed a bug where we cannot fetch the session or the slot information because the AgendaRepository was not ready.