### PR TITLE
Launch screen rocks…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AndroidMakersTheme"
+        android:theme="@style/Theme.AndroidMakers"
         tools:replace="android:theme">
 
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/Theme.AndroidMakers"
+        android:theme="@style/PreviewTheme.AndroidMakers"
         tools:replace="android:theme">
 
         <activity

--- a/app/src/main/java/fr/paug/androidmakers/ui/activity/BaseActivity.java
+++ b/app/src/main/java/fr/paug/androidmakers/ui/activity/BaseActivity.java
@@ -3,11 +3,13 @@ package fr.paug.androidmakers.ui.activity;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
+import fr.paug.androidmakers.util.ThemeUtils;
 
 public class BaseActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
+        ThemeUtils.ensureRuntimeTheme(this);
         super.onCreate(savedInstanceState);
     }
 

--- a/app/src/main/java/fr/paug/androidmakers/ui/activity/BaseActivity.java
+++ b/app/src/main/java/fr/paug/androidmakers/ui/activity/BaseActivity.java
@@ -1,0 +1,14 @@
+package fr.paug.androidmakers.ui.activity;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+
+public class BaseActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+}

--- a/app/src/main/java/fr/paug/androidmakers/ui/activity/DetailActivity.java
+++ b/app/src/main/java/fr/paug/androidmakers/ui/activity/DetailActivity.java
@@ -36,11 +36,7 @@ import fr.paug.androidmakers.service.SessionAlarmService;
 import fr.paug.androidmakers.ui.view.AgendaView;
 import fr.paug.androidmakers.util.SessionSelector;
 
-/**
- * Created by stan on 19/03/2017.
- */
-
-public class DetailActivity extends AppCompatActivity {
+public class DetailActivity extends BaseActivity {
 
     private static final String PARAM_SESSION_ID = "param_session_id";
     private static final String PARAM_SESSION_START_DATE = "param_session_start_date";

--- a/app/src/main/java/fr/paug/androidmakers/ui/activity/MainActivity.java
+++ b/app/src/main/java/fr/paug/androidmakers/ui/activity/MainActivity.java
@@ -14,7 +14,7 @@ import fr.paug.androidmakers.ui.fragment.AboutFragment;
 import fr.paug.androidmakers.ui.fragment.AgendaFragment;
 import fr.paug.androidmakers.ui.fragment.VenuePagerFragment;
 
-public class MainActivity extends AppCompatActivity {
+public class MainActivity extends BaseActivity {
 
     private static final String TAG_FRAGMENT_AGENDA = "TAG_FRAGMENT_AGENDA";
     private static final String TAG_FRAGMENT_VENUE = "TAG_FRAGMENT_VENUE";

--- a/app/src/main/java/fr/paug/androidmakers/util/ThemeUtils.java
+++ b/app/src/main/java/fr/paug/androidmakers/util/ThemeUtils.java
@@ -1,0 +1,30 @@
+package fr.paug.androidmakers.util;
+
+import android.content.Context;
+import android.util.TypedValue;
+
+import fr.paug.androidmakers.R;
+
+public final class ThemeUtils {
+
+    private static final ThreadLocal<TypedValue> TYPED_VALUE = new ThreadLocal<TypedValue>() {
+        @Override
+        protected TypedValue initialValue() {
+            return new TypedValue();
+        }
+    };
+
+    private ThemeUtils() {
+        // No instances
+    }
+
+    public static void ensureRuntimeTheme(Context context) {
+        final TypedValue tv = TYPED_VALUE.get();
+        context.getTheme().resolveAttribute(R.attr.runtimeTheme, tv, true);
+        if (tv.resourceId <= 0) {
+            throw new IllegalArgumentException("runtimeTheme not defined in the preview theme");
+        }
+        context.setTheme(tv.resourceId);
+    }
+
+}

--- a/app/src/main/res/values-v21/themes_preview.xml
+++ b/app/src/main/res/values-v21/themes_preview.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="PreviewTheme.AndroidMakers" parent="@android:style/Theme.Material.Light.DarkActionBar">
+        <item name="android:colorPrimary">@color/colorPrimary</item>
+        <item name="android:colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="android:colorAccent">@color/colorAccent</item>
+        <item name="android:windowBackground">@android:color/white</item>
+        <item name="runtimeTheme">@style/Theme.AndroidMakers</item>
+    </style>
+
+</resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <attr format="reference" name="runtimeTheme" />
+
+</resources>

--- a/app/src/main/res/values/styles_preview.xml
+++ b/app/src/main/res/values/styles_preview.xml
@@ -1,0 +1,8 @@
+<resources>
+
+    <style name="PreviewWidget.ActionBar" parent="android:Widget.Holo.Light.ActionBar.Solid.Inverse">
+        <item name="android:background">@color/colorPrimary</item> 
+        <item name="android:displayOptions">none</item>
+    </style>
+
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="AndroidMakersTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="Theme.AndroidMakers" parent="Theme.AppCompat.Light.DarkActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>

--- a/app/src/main/res/values/themes_preview.xml
+++ b/app/src/main/res/values/themes_preview.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <style name="PreviewTheme.AndroidMakers" parent="@android:style/Theme.Holo.Light.DarkActionBar">
+        <item name="android:actionBarSize" tools:ignore="PrivateResource">
+            @dimen/abc_action_bar_default_height_material
+        </item>
+        <item name="android:actionBarStyle">@style/PreviewWidget.ActionBar</item>
+        <item name="android:windowBackground">@android:color/white</item>
+        <item name="runtimeTheme">@style/Theme.AndroidMakers</item>
+    </style>
+
+</resources>


### PR DESCRIPTION
As stated in my Android Makers talk, the Android Makers schedule app wasn't displaying a correct launch screen. Indeed, only a blank canvas was displayed on cold launch. This merge request fixes the issue by introducing a placeholder UI.

Here is a "before/after" that better showcases the differences introduced in this merge request.

|Before|After|
|------|------|
| ![before](https://cloud.githubusercontent.com/assets/92794/24899451/9e199e52-1ea0-11e7-9aaa-49dfaeebbaef.gif) | ![after](https://cloud.githubusercontent.com/assets/92794/24899459/a20225d4-1ea0-11e7-871d-12c8c45f3687.gif) |



